### PR TITLE
Add an envar to allow passing extra arguments to docker run

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -27,7 +27,16 @@ var settings = {
     images: {
         open365_office: process.env.EYEOS_VIRTUAL_APPLICATION_OPEN365_OFFICE_IMAGE || 'eyeos/open365-office:latest',
         open365_mail: process.env.EYEOS_VIRTUAL_APPLICATION_OPEN365_MAIL_IMAGE || 'eyeos/open365-mail:latest'
-    }
+    },
+    dockerExtraArgs: process.env.OPEN365_DOCKER_EXTRA_ARGS || '[]'
 };
-
+try {
+    settings.dockerExtraArgs = JSON.parse(settings.dockerExtraArgs);
+    if(! Array.isArray(settings.dockerExtraArgs)) {
+        throw new Error("OPEN365_DOCKER_EXTRA_ARGS is valid JSON, but not an array.");
+    }
+} catch(e) {
+    console.log("Error parsing OPEN365_DOCKER_EXTRA_ARGS: Not a valid JSON array");
+    settings.dockerExtraArgs = [];
+}
 module.exports = settings;

--- a/src/index.js
+++ b/src/index.js
@@ -222,6 +222,7 @@ Application.prototype.prepareCommand = function(appInfo, busSubscription) {
     ];
     command = command.concat(envVars);
     command = command.concat(mounts);
+    command = command.concat(settings.dockerExtraArgs);
     command.push(dockerImage, 'exec.sh');
 
     return command;

--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,7 @@ Application.prototype.prepareCommand = function(appInfo, busSubscription) {
     envVars.push("-e", "EYEOS_IMAP_HOST=" + appInfo.imap_host);
     envVars.push("-e", "EYEOS_SMTP_HOST=" + appInfo.smtp_host);
     envVars.push("-e", "USE_BIND_MOUNT_FOR_LIBRARIES=" + appInfo.use_bind_mount_for_libraries);
+    envVars.push("-e", "ENABLE_LIBREOFFICE_AUTOSAVE=" + appInfo.enable_libreoffice_autosave);
     envVars.push("-e", "WEBDAV_HOST=" + (appInfo.webDAVHost || this.busIP));
     envVars.push("-e", "SPICE_RES=" + spiceRes);
     envVars.push("-e", "EYEOS_BUS_MASTER_USER=" + appInfo.minicard);


### PR DESCRIPTION
Depending on some of the hosts' parameters, we may need to pass
configurable arguments to docker run calls (for seccomp, linux
capabilities, etc...).
